### PR TITLE
Refactor deprecated ioutil to os

### DIFF
--- a/WaterMarker.go
+++ b/WaterMarker.go
@@ -35,7 +35,7 @@ func main() {
 	fmt.Println("Using following parameters:")
 	fmt.Printf("- Opacity:          %d\n", watermarkOpacity)
 	fmt.Printf("- Location:         %s\n", watermarkLocation)
-	fmt.Printf("- Scale:            %s\n", watermarkScale)
+	fmt.Printf("- Scale:            %1.1f\n", watermarkScale)
 	fmt.Printf("- Watermark:        %s\n", watermarkFile)
 	fmt.Printf("- Source directory: %s\n", sourceDir)
 	fmt.Printf("- Target directory: %s\n", targetDir)

--- a/WaterMarker.go
+++ b/WaterMarker.go
@@ -9,7 +9,7 @@ import (
 	"image/draw"
 	"image/jpeg"
 	"image/png"
-	"io/ioutil"
+	"io/fs"
 	"log"
 	"os"
 	"path"
@@ -121,12 +121,20 @@ func main() {
 	fmt.Scanln()
 }
 
-func getFiles(dir string) []os.FileInfo {
-	files, err := ioutil.ReadDir(dir)
+func getFiles(dirname string) []os.FileInfo {
+	entries, err := os.ReadDir(dirname)
 	if err != nil {
 		log.Fatal(err)
 	}
-	return files
+	infos := make([]fs.FileInfo, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			log.Fatal(err)
+		}
+		infos = append(infos, info)
+	}
+	return infos
 }
 
 func getParameters() (int, string, float64, string, string, string, bool) {

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,4 @@ module testingapp
 
 go 1.19
 
-require (
-	github.com/kinsey40/pbar v0.0.0-20190815161936-21f8229eaa8a // indirect
-	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
-	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
-	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
-)
+require github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,2 @@
-github.com/kinsey40/pbar v0.0.0-20190815161936-21f8229eaa8a h1:Sn0FUsz+HHYf2ZwvGTmak6WtuG6FFoUpCYZ/bMC4W4I=
-github.com/kinsey40/pbar v0.0.0-20190815161936-21f8229eaa8a/go.mod h1:QwUrOchRIYL3j2lQBls246ox3I5JdnVlbsdVqrvg6kI=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 h1:Y/gsMcFOcR+6S6f3YeMKl5g+dZMEWqcz5Czj/GWYbkM=
-golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
Hey! I saw your post in the golang subreddit about this project and I decided to checkout the source.

While I was looking over the code I saw `ioutil.ReadDir`. It has been [deprecated](https://pkg.go.dev/io/ioutil#ReadDir) since Go 1.16. I thought I'd send you a PR in case you wanted to update.

Cool project!!